### PR TITLE
docs: add notebook index and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # AI-Agent-workshop
-Example of working AI Agents, perfect for beginners
+
+Questo repository raccoglie esempi pratici su agenti e modelli di linguaggio.
+
+## Indice dei contenuti
+
+- [Fondamenti di AI Agents con AutoGen](Basic_of_AI_Agents_with_AutoGen.ipynb) – Introduzione ad AutoGen: definizione di agenti, conversazioni e utilizzo di strumenti.
+- [Esempio di agente con modello locale](AI_Agent_example_with_local_model.ipynb) – Esegue un agente su un modello LLM locale usando Unsloth e Transformers.
+- [Soluzione agentica da un bisogno di business](AI_Agent_solution_from_business_pain-point.ipynb) – Progetta un flusso di tre chiamate per risolvere un pain point aziendale con API compatibile OpenAI.
+- [Agenti CrewAI per supportare i blogger](AI_Agents_with_CrewAI_to_support_bloggers.ipynb) – Crea agenti e task con CrewAI per generare articoli e aggregare informazioni dal web.
+- [Riconoscimento di entità con Hugging Face](EntityRecognition_using_HuggingFace.ipynb) – Mostra una pipeline di Named Entity Recognition e analisi dei risultati.
+- [Fine-tuning per classificazione testuale](FineTuning_Text_Classification.ipynb) – Addestra un modello Sentence Transformers e lo pubblica su Hugging Face.
+- [Primi passi con LangChain](Langchain_getting_started.ipynb) – Introduzione a LangChain, template di prompt e LangChain Expression Language.
+
+## Prerequisiti e Avvio rapido
+
+### Requisiti
+
+- Python 3.10 o superiore
+- Librerie principali: pyautogen, crewai, langchain, transformers, sentence-transformers, datasets, unsloth, accelerate, bitsandbytes, python-dotenv, jupyter
+
+### Installazione
+
+```bash
+pip install -r requirements.txt
+```
+
+### Avvio
+
+```bash
+jupyter notebook
+# oppure
+jupyter lab
+```
+
+Apri quindi il notebook di interesse dalla lista sopra.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+pyautogen
+crewai
+langchain
+transformers
+sentence-transformers
+datasets
+unsloth
+accelerate
+bitsandbytes
+python-dotenv
+jupyter


### PR DESCRIPTION
## Summary
- describe repository purpose at top of README
- add notebook index with descriptions and setup instructions
- include requirements file for quick installation

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf320ff83883269ef3b0e2826f81cb