### PR TITLE
Organize notebooks and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Questo repository raccoglie esempi pratici su agenti e modelli di linguaggio.
 
 ## Indice dei contenuti
 
-- [Fondamenti di AI Agents con AutoGen](Basic_of_AI_Agents_with_AutoGen.ipynb) – Introduzione ad AutoGen: definizione di agenti, conversazioni e utilizzo di strumenti.
-- [Esempio di agente con modello locale](AI_Agent_example_with_local_model.ipynb) – Esegue un agente su un modello LLM locale usando Unsloth e Transformers.
-- [Soluzione agentica da un bisogno di business](AI_Agent_solution_from_business_pain-point.ipynb) – Progetta un flusso di tre chiamate per risolvere un pain point aziendale con API compatibile OpenAI.
-- [Agenti CrewAI per supportare i blogger](AI_Agents_with_CrewAI_to_support_bloggers.ipynb) – Crea agenti e task con CrewAI per generare articoli e aggregare informazioni dal web.
-- [Riconoscimento di entità con Hugging Face](EntityRecognition_using_HuggingFace.ipynb) – Mostra una pipeline di Named Entity Recognition e analisi dei risultati.
-- [Fine-tuning per classificazione testuale](FineTuning_Text_Classification.ipynb) – Addestra un modello Sentence Transformers e lo pubblica su Hugging Face.
-- [Primi passi con LangChain](Langchain_getting_started.ipynb) – Introduzione a LangChain, template di prompt e LangChain Expression Language.
+ - [AI Agents Basics with AutoGen](notebooks/autogen-ai-agents-basics.ipynb) – Introduzione ad AutoGen: definizione di agenti, conversazioni e utilizzo di strumenti.
+ - [Local Model Agent Example](notebooks/ai-agent-local-model-example.ipynb) – Esegue un agente su un modello LLM locale usando Unsloth e Transformers.
+ - [Agentic Solution for Business Pain Points](notebooks/ai-agent-business-solution.ipynb) – Progetta un flusso di tre chiamate per risolvere un pain point aziendale con API compatibile OpenAI.
+ - [CrewAI Agents for Blogger Support](notebooks/crewai-blogger-support.ipynb) – Crea agenti e task con CrewAI per generare articoli e aggregare informazioni dal web.
+ - [Entity Recognition with Hugging Face](notebooks/huggingface-entity-recognition.ipynb) – Mostra una pipeline di Named Entity Recognition e analisi dei risultati.
+ - [Fine-tuning for Text Classification](notebooks/text-classification-finetuning.ipynb) – Addestra un modello Sentence Transformers e lo pubblica su Hugging Face.
+ - [Getting Started with LangChain](notebooks/langchain-getting-started.ipynb) – Introduzione a LangChain, template di prompt e LangChain Expression Language.
 
 ## Prerequisiti e Avvio rapido
 
@@ -22,6 +22,8 @@ Questo repository raccoglie esempi pratici su agenti e modelli di linguaggio.
 ### Installazione
 
 ```bash
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 

--- a/notebooks/ai-agent-business-solution.ipynb
+++ b/notebooks/ai-agent-business-solution.ipynb
@@ -4,7 +4,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Agentic Solution Idea for Business Paint-Point\n",
+        "# Agentic Solution for Business Pain Points\n",
         "\n",
         "\n",
         "*What this notebook does*\n",

--- a/notebooks/ai-agent-local-model-example.ipynb
+++ b/notebooks/ai-agent-local-model-example.ipynb
@@ -20,12 +20,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
+      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatteoRigoni/AI-Agent-workshop/blob/master/AI_Agent_example_with_local_model.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# Local Model Agent Example\n"
       ]
     },
     {

--- a/notebooks/autogen-ai-agents-basics.ipynb
+++ b/notebooks/autogen-ai-agents-basics.ipynb
@@ -18,12 +18,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
+      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatteoRigoni/AI-Agent-workshop/blob/master/Basic_of_AI_Agents_with_AutoGen.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# AI Agents Basics with AutoGen\n"
       ]
     },
     {

--- a/notebooks/crewai-blogger-support.ipynb
+++ b/notebooks/crewai-blogger-support.ipynb
@@ -18,12 +18,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
+      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatteoRigoni/AI-Camp_Agents-Transformers/blob/master/AI_Agents_with_CrewAI_to_support_bloggers.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# CrewAI Agents for Blogger Support\n"
       ]
     },
     {

--- a/notebooks/huggingface-entity-recognition.ipynb
+++ b/notebooks/huggingface-entity-recognition.ipynb
@@ -18,12 +18,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
+      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatteoRigoni/AI-Camp_Agents-Transformers/blob/master/EntityRecognition_using_HuggingFace.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# Entity Recognition with Hugging Face\n"
       ]
     },
     {

--- a/notebooks/langchain-getting-started.ipynb
+++ b/notebooks/langchain-getting-started.ipynb
@@ -18,12 +18,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
+      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatteoRigoni/AI-Camp_LLM-Agents-Transformers/blob/master/Langchain_getting_started.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# Getting Started with LangChain\n"
       ]
     },
     {

--- a/notebooks/text-classification-finetuning.ipynb
+++ b/notebooks/text-classification-finetuning.ipynb
@@ -18,12 +18,9 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
-      },
+      "metadata": {},
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatteoRigoni/AI-Camp_Agents-Transformers/blob/master/FineTuning_Text_Classification.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# Fine-tuning for Text Classification\n"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- rename notebooks to English names without numeric prefixes
- use English H1 titles across notebooks
- refresh README links and setup instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf32bd68f88326a5eccbc813313fde