### PR TITLE
Rename project to AI-agents-camp and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# AI-Agent-workshop
+<p align="center">
+  <img src="assets/ai-agents-banner.svg" alt="AI Agents Camp banner" />
+</p>
+
+# AI-agents-camp
+
+[![GitHub](https://img.shields.io/badge/GitHub-AI--agents--camp-blue?style=for-the-badge&logo=github)](https://github.com/MatteoRigoni/AI-agents-camp)
+
+> **Nota**: repository precedentemente noto come `AI-Camp_LLM-Agents-Transformers`.
+
+
 
 Questo repository raccoglie esempi pratici su agenti e modelli di linguaggio.
 
@@ -36,3 +46,7 @@ jupyter lab
 ```
 
 Apri quindi il notebook di interesse dalla lista sopra.
+
+## Comunicazioni
+
+Se collabori al progetto, aggiorna i link esterni, i webhook e i cloni locali al nuovo repository: https://github.com/MatteoRigoni/AI-agents-camp.

--- a/assets/ai-agents-banner.svg
+++ b/assets/ai-agents-banner.svg
@@ -1,0 +1,10 @@
+<svg width="800" height="200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0072ff;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#00c6ff;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="200" fill="url(#grad)" />
+  <text x="400" y="120" font-size="60" text-anchor="middle" fill="#ffffff" font-family="Arial, Helvetica, sans-serif">AI Agents Camp</text>
+</svg>


### PR DESCRIPTION
## Summary
- rename project to AI-agents-camp
- add banner graphic and GitHub badge
- add collaborator notice to update links and webhooks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf34be6034832681118e09ebd803e9